### PR TITLE
fix: add img render and loading improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -320,6 +320,8 @@ export default function App() {
               <img
                 src="https://www.datocms-assets.com/31049/1618983297-powered-by-vercel.svg"
                 alt="Powered by Vercel"
+                width="116" height="24"
+                loading="lazy"
                 className="inline-block h-6 mb-0.5"
               />
             </a>


### PR DESCRIPTION
This PR includes:
- add width and height to avoid CLS
- add lazy loading to reduce resource download

The CLS issue is only theoretically as the img is off-screen. But the lazy loading helps. 

<img width="870" alt="Screenshot 2023-10-06 at 18 44 04" src="https://github.com/tsperf/website/assets/10064416/7b186c4e-216a-45d7-a6b2-457e52f5be51">

